### PR TITLE
Emulate rails options :words_connector and :last_word_connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@ orange, banana, and pear
 
 That's it.
 
+## Options
+
+The `joined` method supports the following parameters:
+
+* `words_connector` (String) (defaults to: ', ')
+    * The sign or word used to join all but the last element in arrays with three or more elements.
+* `last_word_connector` (String) (defaults to: ', and ')
+    * The sign or word used to join the last element in arrays with three or more element.
+* `oxford` (Boolean) (defaults to: true)
+    * Should we place a comma before the `last_word_connector`?
+    * If false, it will remove a leading comma from the `last_word_connector`
+    * However, it does not add a comma if one is not already specified in the `last_word_connector`.
+
+See the [Yard docs](https://rubydoc.info/github/yegor256/joined/master/frames) for full gem documentation.
+
 ## How to contribute
 
 Read

--- a/README.md
+++ b/README.md
@@ -31,9 +31,16 @@ That's it.
 
 The `joined` method supports the following parameters:
 
-* `words_connector` (String) (defaults to: ', ') - the sign or word used to join all but the last element in arrays with three or more elements.
-* `last_word_connector` (String) (defaults to: ', and ') - the sign or word used to join the last element in arrays with three or more element.
-* `oxford` (Boolean) (defaults to: true) - should we place a comma before the `last_word_connector`? If false, it will remove a leading comma from the `last_word_connector`, however, it does not add a comma if one is not already specified in the `last_word_connector`.
+* `words_connector` (String) (defaults to: ', ') -
+  the sign or word used to join all but the last element
+  in arrays with three or more elements.
+* `last_word_connector` (String) (defaults to: ', and ') -
+  the sign or word used to join the last element in arrays
+  with three or more element.
+* `oxford` (Boolean) (defaults to: true) -
+  should we place a comma before the `last_word_connector`?
+  If false, it will remove a leading comma from the `last_word_connector`,
+  however, it does not add a comma if one is not already specified in the `last_word_connector`.
 
 See the [Yard docs](https://rubydoc.info/github/yegor256/joined/master/frames) for full gem documentation.
 

--- a/README.md
+++ b/README.md
@@ -31,14 +31,9 @@ That's it.
 
 The `joined` method supports the following parameters:
 
-* `words_connector` (String) (defaults to: ', ')
-    * The sign or word used to join all but the last element in arrays with three or more elements.
-* `last_word_connector` (String) (defaults to: ', and ')
-    * The sign or word used to join the last element in arrays with three or more element.
-* `oxford` (Boolean) (defaults to: true)
-    * Should we place a comma before the `last_word_connector`?
-    * If false, it will remove a leading comma from the `last_word_connector`
-    * However, it does not add a comma if one is not already specified in the `last_word_connector`.
+* `words_connector` (String) (defaults to: ', ') - the sign or word used to join all but the last element in arrays with three or more elements.
+* `last_word_connector` (String) (defaults to: ', and ') - the sign or word used to join the last element in arrays with three or more element.
+* `oxford` (Boolean) (defaults to: true) - should we place a comma before the `last_word_connector`? If false, it will remove a leading comma from the `last_word_connector`, however, it does not add a comma if one is not already specified in the `last_word_connector`.
 
 See the [Yard docs](https://rubydoc.info/github/yegor256/joined/master/frames) for full gem documentation.
 

--- a/lib/joined.rb
+++ b/lib/joined.rb
@@ -12,14 +12,24 @@ class Array
   # Join strings into a single line, splitting them with comma
   # and placing "AND" between the last two items.
   #
-  # @param [Boolean] oxford Should we place a comma before AND?
-  # @param [String] words_connector The sign or word used to join all but the last element
-  #   in arrays with three or more elements (default: ", ").
+  # @param [String] words_connector
+  #   The sign or word used to join all but the last element
+  #   in arrays with three or more elements.
+  # @param [String] last_word_connector
+  #   The sign or word used to join the last element in arrays
+  #   with three or more element.
+  # @param [Boolean] oxford
+  #   Should we place a comma before the :last_word_connector?
+  #   If false, it will remove a leading comma from the :last_word_connector,
+  #   however it does not add a comma if one is not already specified in the :last_word_connector.
   # @return [String] The text generated (with items joined)
-  def joined(oxford: true, words_connector: ', ')
+  def joined(oxford: true, words_connector: ', ', last_word_connector: ', and ')
     return '' if empty?
     return first if length == 1
 
-    "#{self[0...-1].join(words_connector)}#{',' if length > 2 && oxford} and #{self[-1]}"
+    final_connector = (last_word_connector || '').dup
+    final_connector.sub!(/^,/, '') unless oxford && length > 2
+
+    "#{self[0...-1].join(words_connector)}#{final_connector}#{self[-1]}"
   end
 end

--- a/lib/joined.rb
+++ b/lib/joined.rb
@@ -13,11 +13,13 @@ class Array
   # and placing "AND" between the last two items.
   #
   # @param [Boolean] oxford Should we place a comma before AND?
+  # @param [String] words_connector The sign or word used to join all but the last element
+  #   in arrays with three or more elements (default: ", ").
   # @return [String] The text generated (with items joined)
-  def joined(oxford: true)
+  def joined(oxford: true, words_connector: ', ')
     return '' if empty?
     return first if length == 1
 
-    "#{self[0...-1].join(', ')}#{',' if length > 2 && oxford} and #{self[-1]}"
+    "#{self[0...-1].join(words_connector)}#{',' if length > 2 && oxford} and #{self[-1]}"
   end
 end

--- a/test/test_joined.rb
+++ b/test/test_joined.rb
@@ -26,6 +26,12 @@ class Testjoined < Minitest::Test
     assert_equal('apple, banana, orange and pear', %w[apple banana orange pear].joined(oxford: false))
   end
 
+  def test_with_words_connector
+    assert_equal('one two, and three', %w[one two three].joined(words_connector: ' '))
+    assert_equal('one & two, and three', %w[one two three].joined(words_connector: ' & '))
+    assert_equal('onetwo, and three', %w[one two three].joined(words_connector: nil))
+  end
+
   def test_with_invalid_options
     exception = assert_raises ArgumentError do
       %w[one two].joined(passing: 'invalid option')

--- a/test/test_joined.rb
+++ b/test/test_joined.rb
@@ -25,4 +25,12 @@ class Testjoined < Minitest::Test
     assert_equal('apple, banana and orange', %w[apple banana orange].joined(oxford: false))
     assert_equal('apple, banana, orange and pear', %w[apple banana orange pear].joined(oxford: false))
   end
+
+  def test_with_invalid_options
+    exception = assert_raises ArgumentError do
+      %w[one two].joined(passing: 'invalid option')
+    end
+
+    assert_equal 'unknown keyword: :passing', exception.message
+  end
 end

--- a/test/test_joined.rb
+++ b/test/test_joined.rb
@@ -32,6 +32,31 @@ class Testjoined < Minitest::Test
     assert_equal('onetwo, and three', %w[one two three].joined(words_connector: nil))
   end
 
+  def test_with_last_word_connector
+    assert_equal 'one, two, and also three', %w[one two three].joined(last_word_connector: ', and also ')
+    assert_equal 'one, two and also three', %w[one two three].joined(last_word_connector: ' and also ')
+    assert_equal 'one, twothree', %w[one two three].joined(last_word_connector: nil)
+    assert_equal 'one, two three', %w[one two three].joined(last_word_connector: ' ')
+    assert_equal 'one, two and three', %w[one two three].joined(last_word_connector: ' and ')
+  end
+
+  def test_with_last_word_connector_but_without_oxford_comma
+    assert_equal 'one, two and also three', %w[one two three].joined(oxford: false, last_word_connector: ', and also ')
+    assert_equal 'one, two and also three', %w[one two three].joined(oxford: false, last_word_connector: ' and also ')
+    assert_equal 'one, twothree', %w[one two three].joined(oxford: false, last_word_connector: nil)
+    assert_equal 'one, two three', %w[one two three].joined(oxford: false, last_word_connector: ' ')
+    assert_equal 'one, two and three', %w[one two three].joined(oxford: false, last_word_connector: ' and ')
+  end
+
+  def test_two_elements
+    assert_equal 'one and two', %w[one two].joined
+    assert_equal 'one two', %w[one two].joined(last_word_connector: ' ')
+  end
+
+  def test_one_element
+    assert_equal 'one', ['one'].joined
+  end
+
   def test_with_invalid_options
     exception = assert_raises ArgumentError do
       %w[one two].joined(passing: 'invalid option')


### PR DESCRIPTION
Sending this PR as I gather the intention is to make `joined` as similar to the Rails `to_sentence` method as possible!

Adds support for the [`to_sentence`](https://api.rubyonrails.org/classes/Array.html#method-i-to_sentence) documented options `:words_connector` and `:last_word_connector`,
while retaining compatibility with the new `oxford` option.

The `oxford` option seems to make the rails `:two_words_connector` option redundant, so I haven't added that.