### PR TITLE
ignore version manager settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .idea/
 .yardoc/
 *.gem
+.ruby-*
 coverage/
 doc/
 node_modules/


### PR DESCRIPTION
Ignore .ruby-* files by default, since these are not explicitly included in the project. Makes it easier for devs using rvm/rbenv or similar to partition their environments.