### PR TITLE
improve options doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,19 @@ That's it.
 The `joined` method supports the following parameters:
 
 * `words_connector` (String) (defaults to: ', ') -
-  the sign or word used to join all but the last element
-  in arrays with three or more elements.
+  the string used to join all but the last element of the list.
 * `last_word_connector` (String) (defaults to: ', and ') -
-  the sign or word used to join the last element in arrays
-  with three or more element.
+  the string used to join the last element of the list.
 * `oxford` (Boolean) (defaults to: true) -
   should we place a comma before the `last_word_connector`?
-  If false, it will remove a leading comma from the `last_word_connector`,
-  however, it does not add a comma if one is not already specified in the `last_word_connector`.
+  If false, it will remove a leading comma from the `last_word_connector`.
+  If true, it will preserve the leading comma specified
+  in the `last_word_connector`, but it will not insert one
+  if not already present.
 
-See the [Yard docs](https://rubydoc.info/github/yegor256/joined/master/frames) for full gem documentation.
+See the
+[Yard docs](https://rubydoc.info/github/yegor256/joined/master/frames)
+for full gem documentation.
 
 ## How to contribute
 

--- a/lib/joined.rb
+++ b/lib/joined.rb
@@ -13,15 +13,15 @@ class Array
   # and placing "AND" between the last two items.
   #
   # @param [String] words_connector
-  #   The sign or word used to join all but the last element
-  #   in arrays with three or more elements.
+  #   The string used to join all but the last element of the list
   # @param [String] last_word_connector
-  #   The sign or word used to join the last element in arrays
-  #   with three or more element.
+  #   The string used to join the last element of the list.
   # @param [Boolean] oxford
   #   Should we place a comma before the :last_word_connector?
-  #   If false, it will remove a leading comma from the :last_word_connector,
-  #   however it does not add a comma if one is not already specified in the :last_word_connector.
+  #   If false, it will remove a leading comma from the :last_word_connector.
+  #   If true, it will preserve the leading comma specified
+  #   in the :last_word_connector, but it will not insert one
+  #   if not already present.
   # @return [String] The text generated (with items joined)
   def joined(oxford: true, words_connector: ', ', last_word_connector: ', and ')
     return '' if empty?


### PR DESCRIPTION
After reading the options doc, I realize the "copied from rails" doc didn't make the best sense. 

So I've tidied it up and hopefully made it clearer and more accurate for `joined` gem. Updated  README and the yard doc.