### PR TITLE
Ensure comma_before test cases cover all behaviour

### DIFF
--- a/test/test_joined.rb
+++ b/test/test_joined.rb
@@ -78,9 +78,11 @@ class Testjoined < Minitest::Test
 
   def test_comma_before_only_handles_trailing_quotes
     assert_equal '"one"-fer, "two," and "three"', ['"one"-fer', '"two"', '"three"'].joined(comma_before: true)
+    assert_equal '"one"-fer, "two", and "three"', ['"one"-fer', '"two"', '"three"'].joined(comma_before: false)
   end
 
-  def test_comma_before_ignores_trailing_whitespace
+  def test_comma_before_collapses_trailing_whitespace
     assert_equal '"one," "two," and "three" ', ['"one" ', '"two" ', '"three" '].joined(comma_before: true)
+    assert_equal '"one" , "two" , and "three" ', ['"one" ', '"two" ', '"three" '].joined(comma_before: false)
   end
 end

--- a/test/test_joined.rb
+++ b/test/test_joined.rb
@@ -65,7 +65,22 @@ class Testjoined < Minitest::Test
     assert_equal 'unknown keyword: :passing', exception.message
   end
 
-  def test_with_comma_before
-    assert_equal '"one," "two," and "three"', %w[one two three].map { |f| "\"#{f}\"" }.joined(comma_before: true)
+  def test_quoted_items_with_comma_before
+    given_list = ['"one"', '"two"', '"three"']
+
+    assert_equal '"one," "two," and "three"', given_list.joined(comma_before: true)
+    assert_equal '"one", "two", and "three"', given_list.joined(comma_before: false)
+    assert_equal '"one", "two", and "three"', given_list.joined
+    assert_equal '"one," "two" and "three"', given_list.joined(comma_before: true, oxford: false)
+    assert_equal '"one", "two" and "three"', given_list.joined(comma_before: false, oxford: false)
+    assert_equal '"one", "two" and "three"', given_list.joined(oxford: false)
+  end
+
+  def test_comma_before_only_handles_trailing_quotes
+    assert_equal '"one"-fer, "two," and "three"', ['"one"-fer', '"two"', '"three"'].joined(comma_before: true)
+  end
+
+  def test_comma_before_ignores_trailing_whitespace
+    assert_equal '"one," "two," and "three" ', ['"one" ', '"two" ', '"three" '].joined(comma_before: true)
   end
 end


### PR DESCRIPTION
Saw the fix in #11 ; here is some extended testing to cover not just the positive case i.e.

* quoted lists with and without `comma_before` specified
* ensure it only modifies quotes at the end of a term
* how it deals with trailing whitespace