### PR TITLE
Update README method documentation to include `comma_before`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ The `joined` method supports the following parameters:
   If true, it will preserve the leading comma specified
   in the `last_word_connector`, but it will not insert one
   if not already present.
+* `comma_before` (Boolean) (defaults to: false) -
+  If true, adds the comma inside quotation marks (e.g. `"one," "two," and "three"`).
+  If false, adds the comma outside quotation marks (e.g. `"one", "two", and "three"`).
 
 See the
 [Yard docs](https://rubydoc.info/github/yegor256/joined/master/frames)

--- a/lib/joined.rb
+++ b/lib/joined.rb
@@ -24,8 +24,8 @@ class Array
   #   if not already present.
   # @param [Boolean] comma_before
   #   Should we move comma before the quotes symbol
-  #   If false, it will do nothing
-  #   If true, it will move all commas before the quotes
+  #   If false, adds the comma outside quotation marks
+  #   If true, adds the comma inside quotation marks
   # @return [String] The text generated (with items joined)
   def joined(oxford: true, words_connector: ', ', last_word_connector: ', and ', comma_before: false)
     return '' if empty?

--- a/lib/joined.rb
+++ b/lib/joined.rb
@@ -35,7 +35,7 @@ class Array
     final_connector.sub!(/^,/, '') unless oxford && length > 2
 
     result = "#{self[0...-1].join(words_connector)}#{final_connector}#{self[-1]}"
-    return result.gsub(/"([^"]+)"\s*,/, '"\1,"') if comma_before
+    result.gsub!(/"([^"]+)"\s*,/, '"\1,"') if comma_before
 
     result
   end

--- a/test/test_joined.rb
+++ b/test/test_joined.rb
@@ -77,12 +77,16 @@ class Testjoined < Minitest::Test
   end
 
   def test_comma_before_only_handles_trailing_quotes
-    assert_equal '"one"-fer, "two," and "three"', ['"one"-fer', '"two"', '"three"'].joined(comma_before: true)
-    assert_equal '"one"-fer, "two", and "three"', ['"one"-fer', '"two"', '"three"'].joined(comma_before: false)
+    given_list = ['"one"-fer', '"two"', '"three"']
+
+    assert_equal '"one"-fer, "two," and "three"', given_list.joined(comma_before: true)
+    assert_equal '"one"-fer, "two", and "three"', given_list.joined(comma_before: false)
   end
 
   def test_comma_before_collapses_trailing_whitespace
-    assert_equal '"one," "two," and "three" ', ['"one" ', '"two" ', '"three" '].joined(comma_before: true)
-    assert_equal '"one" , "two" , and "three" ', ['"one" ', '"two" ', '"three" '].joined(comma_before: false)
+    given_list = ['"one" ', '"two" ', '"three" ']
+
+    assert_equal '"one," "two," and "three" ', given_list.joined(comma_before: true)
+    assert_equal '"one" , "two" , and "three" ', given_list.joined(comma_before: false)
   end
 end


### PR DESCRIPTION
The README still include parameter documentation, so made sure this now include the new `comma_before` option

Also:

* DRYed up some tests
* removed the multiple return paths. This will simplify the addition of any further logic. 